### PR TITLE
Fix B2W2 Funfest Stunky/Glameow

### DIFF
--- a/Gen5/Dumper5.cs
+++ b/Gen5/Dumper5.cs
@@ -333,6 +333,8 @@ public static class Dumper5
         new() { Species = 136, LevelMin = 15, LevelMax = 60, }, // Flareon
         new() { Species = 196, LevelMin = 15, LevelMax = 60, }, // Espeon
         new() { Species = 197, LevelMin = 15, LevelMax = 60, }, // Umbreon
+        new() { Species = 431, LevelMin = 15, LevelMax = 60, }, // Glameow
+        new() { Species = 434, LevelMin = 15, LevelMax = 60, }, // Stunky
         new() { Species = 470, LevelMin = 15, LevelMax = 60, }, // Leafeon
         new() { Species = 471, LevelMin = 15, LevelMax = 60, }, // Glaceon
 
@@ -350,7 +352,6 @@ public static class Dumper5
         Location = 143, // Hidden Grotto
         Slots = [.. SlotsB2W2_HiddenGrottoEncounterSlots,
             new() { Species = 015, LevelMin = 55, LevelMax = 60 }, // Beedrill @ Pinwheel Forest
-            new() { Species = 434, LevelMin = 15, LevelMax = 60 }, // Stunky from Funfest Missions
         ],
     };
 
@@ -359,7 +360,6 @@ public static class Dumper5
         Location = 143, // Hidden Grotto
         Slots = [.. SlotsB2W2_HiddenGrottoEncounterSlots, 
             new() { Species = 012, LevelMin = 55, LevelMax = 60 }, // Butterfree @ Pinwheel Forest
-            new() { Species = 431, LevelMin = 15, LevelMax = 60 }, // Glameow from Funfest Missions
         ],
     };
 


### PR DESCRIPTION
The missions themselves are version-exclusive, but both pokemon can be obtained from either game by joining a mission started by the other version

I've added the new pkl files [here](https://github.com/Parnassius/PKHeX/commit/a9d123a1e5b4cc09be4f6212d5a176c63adb4c14), should I create a pull request on the main repo as well?